### PR TITLE
bump compat of Setfield to v1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 [compat]
 BangBang = "0.3.34"
 InitialValues = "0.2.8, 0.3"
-Setfield = "0.4, 0.5, 0.6, 0.7, 0.8"
+Setfield = "0.4, 0.5, 0.6, 0.7, 0.8, 1.0"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
This requires a new version of BangBang.jl including https://github.com/JuliaFolds/BangBang.jl/pull/229 to test the new version of Setfield.jl.